### PR TITLE
Parameter to specify odom target frame

### DIFF
--- a/launch/hdl_localization.launch
+++ b/launch/hdl_localization.launch
@@ -2,6 +2,9 @@
 <launch>
   <!-- arguments -->
   <arg name="nodelet_manager" default="velodyne_nodelet_manager" />
+  <arg name="points_topic" default="/velodyne_points" />
+  <arg name="imu_topic" default="/gpsimu_driver/imu_data" />
+  <arg name="odom_child_frame_id" default="velodyne" />
 
   <!-- in case you use velodyne_driver, comment out the following line -->
   <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager)" args="manager" output="screen"/>
@@ -14,6 +17,10 @@
 
     <!-- hdl_localization_nodelet -->
     <node pkg="nodelet" type="nodelet" name="hdl_localization_nodelet" args="load hdl_localization/HdlLocalizationNodelet $(arg nodelet_manager)">
+        <remap from="/velodyne_points" to="$(arg points_topic)" />
+        <remap from="/gpsimu_driver/imu_data" to="$(arg imu_topic)" />
+        <!-- odometry frame_id -->
+        <param name="odom_child_frame_id" value="$(arg odom_child_frame_id)" />
         <!-- imu settings -->
         <!-- during "cool_time", imu inputs are ignored -->
         <param name="use_imu" value="true" />


### PR DESCRIPTION
I've made the following changes:
- I've added in the launch file the `<remap>` tags to remap the points topic and the imu topic
- I've added a parameter to specify the target frame against which to compute the odometry. This is useful, for example, if you are using a sensor like the Ouster OS-1 that is characterized by three `frame_id`, namely, `os1_sensor`, `os1_lidar`, and `os1_imu`. Moreover, it is very common in the robotics world to compute the odometry against the `base_link` frame.
- To compute the odometry against a given target frame I've added an instruction to transform the input point cloud into the target frame via a `pcl_ros` library function. If the target `odom_child_frame_id` is the same as that of the input point cloud msg, no transformation is performed. 

This pull request closes #38 