### PR TITLE
Make map server publish point cloud map more reliably at startup

### DIFF
--- a/apps/globalmap_server_nodelet.cpp
+++ b/apps/globalmap_server_nodelet.cpp
@@ -42,7 +42,7 @@ public:
 
     // publish globalmap with "latched" publisher
     globalmap_pub = nh.advertise<sensor_msgs::PointCloud2>("/globalmap", 5, true);
-    timer_ = nh.createWallTimer(ros::WallDuration(0.05), &GlobalmapServerNodelet::pub_once_cb, this, true, true);
+    globalmap_pub_timer = nh.createWallTimer(ros::WallDuration(0.05), &GlobalmapServerNodelet::pub_once_cb, this, true, true);
   }
 
 private:
@@ -77,7 +77,7 @@ private:
 
   ros::Publisher globalmap_pub;
 
-  ros::WallTimer timer_;
+  ros::WallTimer globalmap_pub_timer;
   pcl::PointCloud<PointT>::Ptr globalmap;
 };
 

--- a/apps/globalmap_server_nodelet.cpp
+++ b/apps/globalmap_server_nodelet.cpp
@@ -42,7 +42,7 @@ public:
 
     // publish globalmap with "latched" publisher
     globalmap_pub = nh.advertise<sensor_msgs::PointCloud2>("/globalmap", 5, true);
-    globalmap_pub.publish(globalmap);
+    timer_ = nh.createWallTimer(ros::WallDuration(0.05), &GlobalmapServerNodelet::pub_once_cb, this, true, true);
   }
 
 private:
@@ -65,6 +65,10 @@ private:
     globalmap = filtered;
   }
 
+  void pub_once_cb(const ros::WallTimerEvent& event) {
+    globalmap_pub.publish(globalmap);
+  }
+
 private:
   // ROS
   ros::NodeHandle nh;
@@ -73,6 +77,7 @@ private:
 
   ros::Publisher globalmap_pub;
 
+  ros::WallTimer timer_;
   pcl::PointCloud<PointT>::Ptr globalmap;
 };
 


### PR DESCRIPTION
I noticed that the localization nodelet frequently does not receive the point cloud map from the global map server when launching `hdl_localization.launch`. I did some testing and realized that both initializing the `ros::Publisher` and publishing the map message in the `onInit()` method causes the publisher to not have enough time to start up and the message is lost.

I tried fixing this with a normal delay with `sleep()`, and with `ros::Duration().sleep()`, but the way the threading works in the nodelet prevented that from being successful. I settled on a oneshot `ros::WallTimer` to provide the delay, which is what you see in this PR.

The localization node receives the global map message every time now.