### PR TITLE
Modify CMakeLists.txt to use C++ 17 in ROS Noetic, and C++ 11 in ROS Melodic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hdl_localization)
 
 # -mavx causes a lot of errors!!
-add_definitions(-std=c++11)
-# add_definitions(-std=c++11 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
-# set(CMAKE_CXX_FLAGS "-std=c++11 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+if("$ENV{ROS_DISTRO}" STRGREATER "melodic")
+  add_definitions(-std=c++17 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+  set(CMAKE_CXX_FLAGS "-std=c++17 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+else()
+  add_definitions(-std=c++11 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+  set(CMAKE_CXX_FLAGS "-std=c++11 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+endif()
 
 # pcl 1.7 causes a segfault when it is built with debug mode
 set(CMAKE_BUILD_TYPE "RELEASE")


### PR DESCRIPTION
Using the `ROS_DISTRO` environment variable, this PR causes catkin to build with C++ 17 in ROS Noetic and maintains C++ 11 in ROS Melodic and earlier. Would you prefer just using C++ 14 in all cases like you did in `hdl_graph_slam`? https://github.com/koide3/hdl_graph_slam/pull/148
