### PR TITLE
Offset map points by UTM reference coordinates if a .utm file exists

### DIFF
--- a/apps/globalmap_server_nodelet.cpp
+++ b/apps/globalmap_server_nodelet.cpp
@@ -54,7 +54,7 @@ private:
     globalmap->header.frame_id = "map";
 
     std::ifstream utm_file(globalmap_pcd + ".utm");
-    if (utm_file.is_open()) {
+    if (utm_file.is_open() && private_nh.param<bool>("convert_utm_to_local", true)) {
       double utm_easting;
       double utm_northing;
       double altitude;

--- a/apps/globalmap_server_nodelet.cpp
+++ b/apps/globalmap_server_nodelet.cpp
@@ -53,6 +53,19 @@ private:
     pcl::io::loadPCDFile(globalmap_pcd, *globalmap);
     globalmap->header.frame_id = "map";
 
+    std::ifstream utm_file(globalmap_pcd + ".utm");
+    if (utm_file.is_open()) {
+      double utm_easting;
+      double utm_northing;
+      double altitude;
+      utm_file >> utm_easting >> utm_northing >> altitude;
+      for(auto& pt : globalmap->points) {
+        pt.getVector3fMap() -= Eigen::Vector3f(utm_easting, utm_northing, altitude);
+      }
+      ROS_INFO_STREAM("Global map offset by UTM reference coordinates (x = " 
+                      << utm_easting << ", y = " << utm_northing << ") and altitude (z = " << altitude << ")");
+    }
+
     // downsample globalmap
     double downsample_resolution = private_nh.param<double>("downsample_resolution", 0.1);
     boost::shared_ptr<pcl::VoxelGrid<PointT>> voxelgrid(new pcl::VoxelGrid<PointT>());

--- a/launch/hdl_localization.launch
+++ b/launch/hdl_localization.launch
@@ -12,6 +12,7 @@
     <!-- globalmap_server_nodelet -->
     <node pkg="nodelet" type="nodelet" name="globalmap_server_nodelet" args="load hdl_localization/GlobalmapServerNodelet $(arg nodelet_manager)">
       <param name="globalmap_pcd" value="$(find hdl_localization)/data/map.pcd" />
+      <param name="convert_utm_to_local" value="true" />
       <param name="downsample_resolution" value="0.1" />
     </node>
 


### PR DESCRIPTION
When `hdl_graph_slam` is run with GPS inputs, the map point cloud is saved along with a `.utm` file that stores the UTM coordinates of the map reference point.

This PR updates the global map server to check for the existence of this file in the same directory as the `.pcd` file, and uses it to offset each point in the map when it is loaded from the pcd file. This way, the map point cloud has the same relative coordinates it did when it was built.