### PR TITLE
Check transform with timeout.

### DIFF
--- a/apps/hdl_localization_nodelet.cpp
+++ b/apps/hdl_localization_nodelet.cpp
@@ -203,9 +203,17 @@ private:
     }
 
     // transform pointcloud into odom_child_frame_id
+    std::string tfError;
     pcl::PointCloud<PointT>::Ptr cloud(new pcl::PointCloud<PointT>());
-    if(!pcl_ros::transformPointCloud(odom_child_frame_id, *pcl_cloud, *cloud, this->tf_buffer)) {
-        NODELET_ERROR("point cloud cannot be transformed into target frame!!");
+    if(this->tf_buffer.canTransform(odom_child_frame_id, pcl_cloud->header.frame_id, stamp, ros::Duration(0.1), &tfError))
+    {
+        if(!pcl_ros::transformPointCloud(odom_child_frame_id, *pcl_cloud, *cloud, this->tf_buffer)) {
+            NODELET_ERROR("point cloud cannot be transformed into target frame!!");
+            return;
+        }
+    }else
+    {
+        NODELET_ERROR(tfError.c_str());
         return;
     }
 


### PR DESCRIPTION
I ran into an issue where the call to transformPointcloud always failed, because the tf2_ros::Buffer did not update fast enough. As transformPointcloud does not forward the duration to lookupTransform, I solved it by explicitly checking the transform before transforming the point cloud.